### PR TITLE
Re-implement sky fog from vanilla

### DIFF
--- a/src/main/java/setadokalo/customfog/mixin/RendererMixin.java
+++ b/src/main/java/setadokalo/customfog/mixin/RendererMixin.java
@@ -52,23 +52,32 @@ public class RendererMixin {
 					CustomFog.config.defaultConfig
 				)
 			);
-			changeFalloff(viewDistance, config);
+			
+			changeFalloff(viewDistance, config, fogType);
 		}
 	}
 
-	private static void changeFalloff(float viewDistance, DimensionConfig config) {
+	private static void changeFalloff(float viewDistance, DimensionConfig config, BackgroundRenderer.FogType fogType) {
 		if (config.getEnabled()) {
-			if (config.getType() == CustomFogConfig.FogType.LINEAR) {
-				RenderSystem.fogStart(viewDistance * config.getLinearStart());
-				RenderSystem.fogEnd(viewDistance * config.getLinearEnd());
+			// Try applying fog for sky
+			if (fogType == BackgroundRenderer.FogType.FOG_SKY) {
+				RenderSystem.fogStart(0.0f);
+				RenderSystem.fogEnd(viewDistance);
 				RenderSystem.fogMode(GlStateManager.FogMode.LINEAR);
-			}
-			else if (config.getType() == CustomFogConfig.FogType.EXPONENTIAL) {
-				RenderSystem.fogDensity(config.getExp() / viewDistance);
-				RenderSystem.fogMode(GlStateManager.FogMode.EXP);
-			} else if (config.getType() == CustomFogConfig.FogType.EXPONENTIAL_TWO) {
-				RenderSystem.fogDensity(config.getExp2() / viewDistance);
-				RenderSystem.fogMode(GlStateManager.FogMode.EXP2);
+			} else {
+				// Otherwise, apply terrain fog
+				if (config.getType() == CustomFogConfig.FogType.LINEAR) {
+					RenderSystem.fogStart(viewDistance * config.getLinearStart());
+					RenderSystem.fogEnd(viewDistance * config.getLinearEnd());
+					RenderSystem.fogMode(GlStateManager.FogMode.LINEAR);
+				}
+				else if (config.getType() == CustomFogConfig.FogType.EXPONENTIAL) {
+					RenderSystem.fogDensity(config.getExp() / viewDistance);
+					RenderSystem.fogMode(GlStateManager.FogMode.EXP);
+				} else if (config.getType() == CustomFogConfig.FogType.EXPONENTIAL_TWO) {
+					RenderSystem.fogDensity(config.getExp2() / viewDistance);
+					RenderSystem.fogMode(GlStateManager.FogMode.EXP2);
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Hiya, this mod appears to overwrite the vanilla behavior for applying fog to the sky, so I re-added it.

Vanilla applies a fog layer for both the sky and terrain.  Custom Fog currently does not render the former at all, so the horizon appears as a distinct band, much more noticeably with very far fog starts (or disabled fog).  Here's an image album with comparisons: https://imgur.com/a/wnRik9G

Thanks for considering! 